### PR TITLE
Promisified the library + added XO and AVA

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,23 +4,29 @@ var osTmpdir = require('os-tmpdir');
 var fs = require('graceful-fs');
 var mkdirp = require('mkdirp');
 var uuid = require('uuid');
+var PinkiePromise = require('pinkie-promise');
 var TMP_DIR = osTmpdir();
 
 function tempfile(filepath) {
 	return path.join(TMP_DIR, uuid.v4(), (filepath || ''));
 }
 
-module.exports = function (str, filepath, cb) {
-	if (typeof filepath === 'function') {
-		cb = filepath;
-		filepath = null;
-	}
+module.exports = function (str, filepath) {
+	return new PinkiePromise(function (resolve, reject) {
+		var fullpath = tempfile(filepath);
 
-	var fullpath = tempfile(filepath);
+		mkdirp(path.dirname(fullpath), function (err) {
+			if (err) {
+				return reject(err);
+			}
 
-	mkdirp(path.dirname(fullpath), function (err) {
-		fs.writeFile(fullpath, str, function (err) {
-			cb(err, fullpath);
+			fs.writeFile(fullpath, str, function (err) {
+				if (err) {
+					return reject(err);
+				}
+
+				resolve(fullpath);
+			});
 		});
 	});
 };

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "graceful-fs": "^4.1.2",
     "mkdirp": "^0.5.0",
     "os-tmpdir": "^1.0.0",
-    "pinkie-promise": "^1.0.0",
+    "pify": "^2.2.0",
     "uuid": "^2.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "xo && ava"
   },
   "files": [
     "index.js"
@@ -37,9 +37,16 @@
     "graceful-fs": "^4.1.2",
     "mkdirp": "^0.5.0",
     "os-tmpdir": "^1.0.0",
+    "pinkie-promise": "^1.0.0",
     "uuid": "^2.0.1"
   },
   "devDependencies": {
-    "mocha": "*"
+    "ava": "*",
+    "xo": "*"
+  },
+  "xo": {
+    "ignores": [
+      "test.js"
+    ]
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -33,28 +33,25 @@ tempWrite.sync('unicorn', 'rainbow/cake/pony.png');
 
 ## API
 
-### tempWrite(input, [filepath], callback)
+### tempWrite(input, [filepath])
+
+Returns a Promise.
 
 #### input
 
-*Required*  
+*Required*
 Type: `string`, `buffer`
 
 #### filepath
 
-Type: `string`  
+Type: `string`
 Example: `'img.png'`, `'foo/bar/baz.png'`
 
 Optionally supply a filepath which is appended to the random path.
 
-#### callback(err, filepath)
-
-*Required*  
-Type: `function`
-
 ### tempWrite.sync(input)
 
-Type: `string`, `buffer`  
+Type: `string`, `buffer`
 Returns: the filepath
 
 

--- a/readme.md
+++ b/readme.md
@@ -35,11 +35,11 @@ tempWrite.sync('unicorn', 'rainbow/cake/pony.png');
 
 ### tempWrite(input, [filepath])
 
-Returns a Promise.
+Returns a promise that resolves to the filepath of the temp file.
 
 #### input
 
-*Required*
+*Required*  
 Type: `string`, `buffer`
 
 #### filepath

--- a/test.js
+++ b/test.js
@@ -1,36 +1,51 @@
 'use strict';
 var fs = require('fs');
+var test = require('ava');
 var path = require('path');
-var assert = require('assert');
 var tempWrite = require('./');
 
-describe('writeTemp()', function () {
-	it('should write string to a random temp file', function (cb) {
-		tempWrite('unicorn', 'test.png', function (err, filepath) {
-			assert.equal(fs.readFileSync(filepath, 'utf8'), 'unicorn');
-			assert.equal(path.basename(filepath), 'test.png');
-			cb();
-		});
-	});
+test('writeTemp(string)', async t => {
+	try {
+		var filepath = await tempWrite('unicorn', 'test.png');
 
-	it('should write buffer to a random temp file', function (cb) {
-		tempWrite(new Buffer('unicorn'), function (err, filepath) {
-			assert.equal(fs.readFileSync(filepath, 'utf8'), 'unicorn');
-			cb();
-		});
-	});
-
-	it('should write string to a random temp filepath', function (cb) {
-		tempWrite('unicorn', 'foo/bar/test.png', function (err, filepath) {
-			assert.equal(fs.readFileSync(filepath, 'utf8'), 'unicorn');
-			assert(/foo\/bar\/test\.png$/.test(filepath));
-			cb();
-		});
-	});
+		t.is(fs.readFileSync(filepath, 'utf8'), 'unicorn');
+		t.is(path.basename(filepath), 'test.png');
+		t.end();
+	}
+	catch (err) {
+		t.fail(err);
+		t.end();
+	}
 });
 
-describe('writeTemp.sync()', function () {
-	it('should write to a random temp file async', function () {
-		assert.equal(fs.readFileSync(tempWrite.sync('unicorn'), 'utf8'), 'unicorn');
-	});
+test('writeTemp(buffer)', async t => {
+	try {
+		var filepath = await tempWrite(new Buffer('unicorn'), 'test.png');
+
+		t.is(fs.readFileSync(filepath, 'utf8'), 'unicorn');
+		t.end();
+	}
+	catch (err) {
+		t.fail(err);
+		t.end();
+	}
+});
+
+test('writeTemp(string, path)', async t => {
+	try {
+		var filepath = await tempWrite(new Buffer('unicorn'), 'foo/bar/test.png');
+
+		t.is(fs.readFileSync(filepath, 'utf8'), 'unicorn');
+		t.regexTest(/foo\/bar\/test\.png$/, filepath);
+		t.end();
+	}
+	catch (err) {
+		t.fail(err);
+		t.end();
+	}
+});
+
+test('writeTemp.sync()', t => {
+	t.is(fs.readFileSync(tempWrite.sync('unicorn'), 'utf8'), 'unicorn');
+	t.end();
 });

--- a/test.js
+++ b/test.js
@@ -3,48 +3,30 @@ import test from 'ava';
 import path from 'path';
 import tempWrite from './';
 
-test('writeTemp(string)', async t => {
-	try {
-		var filepath = await tempWrite('unicorn', 'test.png');
+test('tempWrite(string)', async t => {
+	const filepath = await tempWrite('unicorn', 'test.png');
 
-		t.is(fs.readFileSync(filepath, 'utf8'), 'unicorn');
-		t.is(path.basename(filepath), 'test.png');
-		t.end();
-	}
-	catch (err) {
-		t.fail(err);
-		t.end();
-	}
+	t.is(fs.readFileSync(filepath, 'utf8'), 'unicorn');
+	t.is(path.basename(filepath), 'test.png');
+	t.end();
 });
 
-test('writeTemp(buffer)', async t => {
-	try {
-		var filepath = await tempWrite(new Buffer('unicorn'), 'test.png');
+test('tempWrite(buffer)', async t => {
+	const filepath = await tempWrite(new Buffer('unicorn'), 'test.png');
 
-		t.is(fs.readFileSync(filepath, 'utf8'), 'unicorn');
-		t.end();
-	}
-	catch (err) {
-		t.fail(err);
-		t.end();
-	}
+	t.is(fs.readFileSync(filepath, 'utf8'), 'unicorn');
+	t.end();
 });
 
-test('writeTemp(string, path)', async t => {
-	try {
-		var filepath = await tempWrite(new Buffer('unicorn'), 'foo/bar/test.png');
+test('tempWrite(string, path)', async t => {
+	const filepath = await tempWrite(new Buffer('unicorn'), 'foo/bar/test.png');
 
-		t.is(fs.readFileSync(filepath, 'utf8'), 'unicorn');
-		t.regexTest(/foo\/bar\/test\.png$/, filepath);
-		t.end();
-	}
-	catch (err) {
-		t.fail(err);
-		t.end();
-	}
+	t.is(fs.readFileSync(filepath, 'utf8'), 'unicorn');
+	t.regexTest(/foo\/bar\/test\.png$/, filepath);
+	t.end();
 });
 
-test('writeTemp.sync()', t => {
+test('tempWrite.sync()', t => {
 	t.is(fs.readFileSync(tempWrite.sync('unicorn'), 'utf8'), 'unicorn');
 	t.end();
 });

--- a/test.js
+++ b/test.js
@@ -1,8 +1,7 @@
-'use strict';
-var fs = require('fs');
-var test = require('ava');
-var path = require('path');
-var tempWrite = require('./');
+import fs from 'fs';
+import test from 'ava';
+import path from 'path';
+import tempWrite from './';
 
 test('writeTemp(string)', async t => {
 	try {


### PR DESCRIPTION
Resolves #3 

Also added XO and AVA for testing. One thing to notice, I ignored `test.js` from XO because I used async/await. In order to use these features, I had to add ignore the test file because it was complaining about those keywords. When using `esnext: true`, it complains that I should use const instead of var and all the other non-esnext features :).

Is it possible to only set esnext in a specific file?