### PR TITLE
Passing pinkie-promise as promise library to pify + fixed test

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var fs = require('graceful-fs');
 var mkdirp = require('mkdirp');
 var uuid = require('uuid');
 var pify = require('pify');
+var Promise = require('pinkie-promise');
 var TMP_DIR = osTmpdir();
 
 function tempfile(filepath) {
@@ -14,9 +15,9 @@ function tempfile(filepath) {
 module.exports = function (str, filepath) {
 	var fullpath = tempfile(filepath);
 
-	return pify(mkdirp)(path.dirname(fullpath))
+	return pify(mkdirp, Promise)(path.dirname(fullpath))
 		.then(function () {
-			return pify(fs.writeFile)(fullpath, str);
+			return pify(fs.writeFile, Promise)(fullpath, str);
 		})
 		.then(function () {
 			return fullpath;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "mkdirp": "^0.5.0",
     "os-tmpdir": "^1.0.0",
     "pify": "^2.2.0",
+    "pinkie-promise": "^1.0.0",
     "uuid": "^2.0.1"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -25,4 +25,5 @@ test('tempWrite(string, path)', async t => {
 
 test('tempWrite.sync()', t => {
 	t.is(fs.readFileSync(fn.sync('unicorn'), 'utf8'), 'unicorn');
+	t.end();
 });


### PR DESCRIPTION
As you pointed out here https://github.com/sindresorhus/pageres/pull/212#issuecomment-145344493, `pinkie-promise` should be passed into pify.

I have tested this with node 0.12, without passing `pinkie-promise` to pify and it still worked. Do you have any explanation to it because this does not seem correct :).

Also fixed the non-async test https://github.com/sindresorhus/temp-write/commit/15b1e24c338c52d6a5344f429fe97fe8e839c76a#commitcomment-13581250 ;).