### PR TITLE
Add stream support - fixes #6

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,13 +19,13 @@ module.exports = function (str, filepath) {
 
 	return pify(mkdirp, Promise)(path.dirname(fullpath))
 		.then(function () {
-			const pipeStream = () => {
-				return new Promise((resolve, reject) => {
+			function pipeStream() {
+				return new Promise(function (resolve, reject) {
 					str.pipe(fs.createWriteStream(fullpath))
 						.on('error', reject)
 						.on('finish', resolve);
 				});
-			};
+			}
 			return isStream(str) ? pipeStream() : pify(fs.writeFile, Promise)(fullpath, str);
 		})
 		.then(function () {

--- a/index.js
+++ b/index.js
@@ -19,13 +19,14 @@ module.exports = function (str, filepath) {
 
 	return pify(mkdirp, Promise)(path.dirname(fullpath))
 		.then(function () {
-			return isStream(str) ?
-				new Promise((resolve, reject) => {
+			const pipeStream = () => {
+				return new Promise((resolve, reject) => {
 					str.pipe(fs.createWriteStream(fullpath))
 						.on('error', reject)
 						.on('finish', resolve);
-				}) :
-				pify(fs.writeFile, Promise)(fullpath, str);
+				});
+			};
+			return isStream(str) ? pipeStream() : pify(fs.writeFile, Promise)(fullpath, str);
 		})
 		.then(function () {
 			return fullpath;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "temp-write",
   "version": "2.1.0",
-  "description": "Write string/stream/buffer to a random temp file",
+  "description": "Write string/buffer/stream to a random temp file",
   "license": "MIT",
   "repository": "sindresorhus/temp-write",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "temp-write",
   "version": "2.1.0",
-  "description": "Write string/buffer to a random temp file",
+  "description": "Write string/stream/buffer to a random temp file",
   "license": "MIT",
   "repository": "sindresorhus/temp-write",
   "author": {
@@ -35,6 +35,7 @@
   ],
   "dependencies": {
     "graceful-fs": "^4.1.2",
+    "is-stream": "^1.1.0",
     "mkdirp": "^0.5.0",
     "os-tmpdir": "^1.0.0",
     "pify": "^2.2.0",

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # temp-write [![Build Status](https://travis-ci.org/sindresorhus/temp-write.svg?branch=master)](https://travis-ci.org/sindresorhus/temp-write)
 
-> Write string/stream/buffer to a random temp file
+> Write string/buffer/stream to a random temp file
 
 
 ## Install

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # temp-write [![Build Status](https://travis-ci.org/sindresorhus/temp-write.svg?branch=master)](https://travis-ci.org/sindresorhus/temp-write)
 
-> Write string/buffer to a random temp file
+> Write string/stream/buffer to a random temp file
 
 
 ## Install
@@ -43,7 +43,9 @@ Returns the filepath of the temp file.
 
 #### input
 
-Type: `string`, `buffer`
+Type: `string`, `stream`, `buffer`
+
+The data to write to the temp file. Streams are supported only on the async API.
 
 #### filepath
 

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import stream from 'stream';
 import test from 'ava';
 import m from './';
 
@@ -9,12 +10,22 @@ test('tempWrite(string)', async t => {
 	t.is(path.basename(filepath), 'test.png');
 });
 
+test('tempWrite(stream)', async t => {
+	const readable = new stream.Readable({
+		read() { /* noop */ }
+	});
+	readable.push('unicorn');
+	readable.push(null);
+	const filepath = await m(readable, 'test.png');
+	t.is(fs.readFileSync(filepath, 'utf8'), 'unicorn');
+});
+
 test('tempWrite(buffer)', async t => {
 	const filepath = await m(new Buffer('unicorn'), 'test.png');
 	t.is(fs.readFileSync(filepath, 'utf8'), 'unicorn');
 });
 
-test('tempWrite(string, path)', async t => {
+test('tempWrite(buffer, path)', async t => {
 	const filepath = await m(new Buffer('unicorn'), 'foo/bar/test.png');
 	t.is(fs.readFileSync(filepath, 'utf8'), 'unicorn');
 	t.regex(filepath, /foo\/bar\/test\.png$/);

--- a/test.js
+++ b/test.js
@@ -10,16 +10,6 @@ test('tempWrite(string)', async t => {
 	t.is(path.basename(filepath), 'test.png');
 });
 
-test('tempWrite(stream)', async t => {
-	const readable = new stream.Readable({
-		read() { /* noop */ }
-	});
-	readable.push('unicorn');
-	readable.push(null);
-	const filepath = await m(readable, 'test.png');
-	t.is(fs.readFileSync(filepath, 'utf8'), 'unicorn');
-});
-
 test('tempWrite(buffer)', async t => {
 	const filepath = await m(new Buffer('unicorn'), 'test.png');
 	t.is(fs.readFileSync(filepath, 'utf8'), 'unicorn');
@@ -29,6 +19,16 @@ test('tempWrite(buffer, path)', async t => {
 	const filepath = await m(new Buffer('unicorn'), 'foo/bar/test.png');
 	t.is(fs.readFileSync(filepath, 'utf8'), 'unicorn');
 	t.regex(filepath, /foo\/bar\/test\.png$/);
+});
+
+test('tempWrite(stream)', async t => {
+	const readable = new stream.Readable({
+		read() { /* noop */ }
+	});
+	readable.push('unicorn');
+	readable.push(null);
+	const filepath = await m(readable, 'test.png');
+	t.is(fs.readFileSync(filepath, 'utf8'), 'unicorn');
 });
 
 test('tempWrite.sync()', t => {


### PR DESCRIPTION
As discussed in #6, you may now pass a [ReadableStream](https://nodejs.org/api/stream.html#stream_class_stream_readable) as input and it will be piped to the filesystem.