### PR TITLE
Resolve the path to the temp directory

### DIFF
--- a/fixture-symlink
+++ b/fixture-symlink
@@ -1,0 +1,1 @@
+fixture

--- a/index.js
+++ b/index.js
@@ -8,7 +8,18 @@ const uuid = require('uuid');
 const pify = require('pify');
 
 const TMP_DIR = os.tmpdir();
-const tempfile = filepath => path.join(TMP_DIR, uuid.v4(), (filepath || ''));
+
+// Workaround for https://github.com/nodejs/node/issues/11422
+let _resolved;
+const getTmpDir = () => {
+	if (!_resolved) {
+		_resolved = fs.realpathSync(TMP_DIR);
+	}
+
+	return _resolved;
+};
+
+const tempfile = filepath => path.join(getTmpDir(), uuid.v4(), (filepath || ''));
 
 const writeStream = (filepath, input) => new Promise((resolve, reject) => {
 	const writable = fs.createWriteStream(filepath);

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "ava": "*",
+    "proxyquire": "^1.7.11",
     "xo": "*"
   }
 }

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import stream from 'stream';
 import test from 'ava';
+import proxyquire from 'proxyquire';
 import m from '.';
 
 test('tempWrite(string)', async t => {
@@ -33,4 +34,18 @@ test('tempWrite(stream)', async t => {
 
 test('tempWrite.sync()', t => {
 	t.is(fs.readFileSync(m.sync('unicorn'), 'utf8'), 'unicorn');
+});
+
+test.serial('ensure the returned filepath is not a symlink', t => {
+	const m = proxyquire('.', {
+		os: {
+			tmpdir: () => path.resolve('fixture-symlink')
+		}
+	});
+
+	const fp = m.sync('unicorn');
+	t.is(fp, fs.realpathSync(fp));
+	t.is(fs.readFileSync(fp, 'utf8'), 'unicorn');
+
+	fs.unlinkSync(fp);
 });


### PR DESCRIPTION
To work around: https://github.com/nodejs/node/issues/11422

Fixes #8

I went with resolving the path synchronously and lazily once. It's done sync in the async method too, but only once, so I think that's an ok compromise.