### PR TITLE
Improve stream handling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,6 @@ jobs:
         node-version:
           - 14
           - 12
-          - 10
-          - 8
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/index.js
+++ b/index.js
@@ -13,9 +13,7 @@ const pipelineP = promisify(stream.pipeline);
 
 const tempfile = filePath => path.join(tempDir, uuid.v4(), (filePath || ''));
 
-const writeStream = async (filePath, fileContent) => {
-	await pipelineP(fileContent, fs.createWriteStream(filePath));
-};
+const writeStream = async (filePath, data) => pipelineP(data, fs.createWriteStream(filePath));
 
 module.exports = async (fileContent, filePath) => {
 	const tempPath = tempfile(filePath);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"url": "https://sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=8"
+		"node": ">=14"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"url": "https://sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=14"
+		"node": ">=12"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"


### PR DESCRIPTION
This PR aims to clean up the stream implementation by using the modern [`stream.pipeline()`](https://nodejs.org/api/stream.html#stream_stream_pipeline_source_transforms_destination_callback) method instead of `readable.pipe()`.

The change is not only cosmetic. This should reduce the chance of memory leaks and other problems, as `pipeline()` automatically forwards errors and destroys the streams if they error. It also has special handling for legacy streams, which we didn't have previously. So this should improve compatibility with the rest of the ecosystem. Although, it does require an upgrade to recent versions of Node, as `pipeline()` was introduced in Node 10 and the legacy compatibility was introduced in Node 14.